### PR TITLE
fix: correct list item indentation

### DIFF
--- a/exampleSite/content/_index.md
+++ b/exampleSite/content/_index.md
@@ -46,3 +46,10 @@ date: 2023-08-02
 ## Custom icon
 
 {{< icon custom activity fa-4x >}}
+
+## List
+
+- {{< fas class="location-dot" wrapper="fa-li" >}} This is the first list item
+- {{< fas class="utensils" wrapper="fa-li" >}} This is the second list item
+- {{< fas class="truck" wrapper="fa-li" >}} This is the third and final list item
+{.fa-ul}

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -5,6 +5,9 @@ title = 'Test site for mod-fontawesome'
 [markup.goldmark.renderer]
 unsafe = true
 
+[markup.goldmark.parser.attribute]
+block = true
+
 [module]
   replacements = 'github.com/gethinode/mod-fontawesome -> ../..'
   [[module.imports]]

--- a/layouts/shortcodes/fa.html
+++ b/layouts/shortcodes/fa.html
@@ -6,7 +6,7 @@
     {{- $class = .Get "class" -}}
     {{- $style = .Get "style" -}}
     {{- $wrapper = .Get "wrapper" -}}
-    {{- $spacing = .Get "spacing" | default true -}}
+    {{- $spacing = .Get "spacing" | default (not (in (split $wrapper " ") "fa-li")) -}}
 {{- else -}}
     {{- $class = delimit .Params " " -}}
 {{- end -}}

--- a/layouts/shortcodes/fab.html
+++ b/layouts/shortcodes/fab.html
@@ -6,7 +6,7 @@
     {{- $class = .Get "class" -}}
     {{- $style = .Get "style" -}}
     {{- $wrapper = .Get "wrapper" -}}
-    {{- $spacing = .Get "spacing" | default true -}}
+    {{- $spacing = .Get "spacing" | default (not (in (split $wrapper " ") "fa-li")) -}}
 {{- else -}}
     {{- $class = delimit .Params " " -}}
 {{- end -}}

--- a/layouts/shortcodes/fas.html
+++ b/layouts/shortcodes/fas.html
@@ -6,7 +6,7 @@
     {{- $class = .Get "class" -}}
     {{- $style = .Get "style" -}}
     {{- $wrapper = .Get "wrapper" -}}
-    {{- $spacing = .Get "spacing" | default true -}}
+    {{- $spacing = .Get "spacing" | default (not (in (split $wrapper " ") "fa-li")) -}}
 {{- else -}}
     {{- $class = delimit .Params " " -}}
 {{- end -}}

--- a/layouts/shortcodes/icon.html
+++ b/layouts/shortcodes/icon.html
@@ -6,7 +6,7 @@
     {{- $class = .Get "class" -}}
     {{- $style = .Get "style" -}}
     {{- $wrapper = .Get "wrapper" -}}
-    {{- $spacing = .Get "spacing" | default true -}}
+    {{- $spacing = .Get "spacing" | default (not (in (split $wrapper " ") "fa-li")) -}}
 {{- else -}}
     {{- $class = delimit .Params " " -}}
 {{- end -}}


### PR DESCRIPTION
Fix indentation of list items that are word-wrapped across multiple lines. When a wrapper element `fa-li` is provided, the `spacing` argument defaults to false. It can still be explicitly set.