### PR TITLE
Make it possible to use icons if current page context not available

### DIFF
--- a/layouts/_partials/assets/icon.html
+++ b/layouts/_partials/assets/icon.html
@@ -98,7 +98,7 @@
                 {{- end -}}
                 
                 {{- $output = printf $inject $family $name $attr (or $style "") -}}
-                {{- if site.Params.modules.fontawesome.embed -}}
+                {{- if and (site.Params.modules.fontawesome.embed) ( page ) -}}
                     {{- $definition := index (findRE "<svg[^>]*>" $output 1) 0 -}}
                     {{- $output = printf `%s<use href="#%s-%s"></use></svg>` $definition $family $name -}}
                     {{- $entry := replaceRE "^<svg " (printf `<symbol id="%s-%s"` $family $name) $content -}}


### PR DESCRIPTION
If I'd like to use button with icon in js script as partial, when executing it as template, then I see errors unless I disable symbol maps. This workaround will just check if current page context exists and add icon to symbol maps only if that's the case.