### PR TITLE
ci: update Install Dart Sass step to use direct binary download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,23 @@ jobs:
         cache-dependency-path: '**/package-lock.json'
 
     - name: Install Dart Sass
-      run:  |
+      env:
+        DART_SASS_VERSION: "1.98.0"
+      run: |
         if [ "$RUNNER_OS" == "Linux" ]; then
-          sudo snap install dart-sass
+          curl -fsSL "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-linux-x64.tar.gz" \
+            | tar -xz -C "$HOME"
+          echo "$HOME/dart-sass" >> $GITHUB_PATH
         elif [ "$RUNNER_OS" == "macOS" ]; then
-          brew install sass/sass/sass
+          ARCH=$(uname -m)
+          if [ "$ARCH" == "arm64" ]; then
+            SASS_ARCH="macos-arm64"
+          else
+            SASS_ARCH="macos-x64"
+          fi
+          curl -fsSL "https://github.com/sass/dart-sass/releases/download/${DART_SASS_VERSION}/dart-sass-${DART_SASS_VERSION}-${SASS_ARCH}.tar.gz" \
+            | tar -xz -C "$HOME"
+          echo "$HOME/dart-sass" >> $GITHUB_PATH
         elif [ "$RUNNER_OS" == "Windows" ]; then
           choco install sass
         fi


### PR DESCRIPTION
Replace snap-based Linux install and brew-based macOS install with versioned curl downloads, adding arch-aware macOS support and pinning to version 1.98.0, matching the reference implementation in gethinode/hinode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)