### PR TITLE
fix: render SVG symbol sprite in deterministic order

### DIFF
--- a/layouts/_partials/assets/symbols.html
+++ b/layouts/_partials/assets/symbols.html
@@ -45,7 +45,9 @@
         {{- printf "<!-- SVG symbol map -->" | safeHTML }}
     {{ end -}}
 
+    {{/* Icons register in first-use order, which races across pages when the first use
+         sits inside a cached partial; sort so identical icon sets emit identical bytes. */}}
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" display="none">
-        {{ delimit (.Scratch.Get "icons" | uniq) "\n" | safeHTML }}
+        {{ delimit (sort (.Scratch.Get "icons" | uniq)) "\n" | safeHTML }}
     </svg>
 {{ end }}


### PR DESCRIPTION
## Problem

The SVG symbol sprite renders `.Scratch.Get "icons" | uniq`, i.e. icons in first-use registration order. When an icon's first use sits inside a cached partial (`partialCached`), registration only executes on whichever page renders that partial first. That race can land on a different page from build to build, so `uniq` keeps a different first occurrence and the symbol shifts position: two builds of an unchanged site emit byte-different sprites on many pages.

This breaks byte-level build comparison, which Hinode needs as a regression gate for upcoming build-performance work.

## Fix

Sort the deduplicated symbol entries before rendering. Entries are unique per icon, so the order is total and deterministic. Behavior is otherwise unchanged.

## Verification

Against the Hinode exampleSite (110 sprite-bearing pages, 3 languages):

- Symbol **sets** per page are identical to stock — order-only change.
- Two consecutive builds with the fix are byte-identical across all HTML output (previously sprites could reorder between runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)