### PR TITLE
feat: page threading, Store registration, and per-call mode override (render-once D2)

### DIFF
--- a/data/structures/icon.yml
+++ b/data/structures/icon.yml
@@ -7,6 +7,29 @@ comment: >-
   icons.
 
 arguments:
+  page:
+    optional: true
+    release: v6.1.0
+    comment: >-
+      Page that owns the icon. When set, symbol registration in `symbols` mode
+      lands on this page instead of the page that triggered the current
+      rendering context, which keeps icon sprites intact when the icon renders
+      in a foreign context (such as a cached partial or another page's
+      `.Content` render). Falls back to the global page context when omitted.
+  mode:
+    type: select
+    optional: true
+    group: partial
+    release: v6.1.0
+    comment: >-
+      Per-call override of the globally configured rendering mode. For example,
+      pass `svg` to force a single icon to render as an inline SVG, bypassing
+      sprite registration. Defaults to the mode set in the site configuration.
+    options:
+      values:
+        - symbols
+        - svg
+        - webfonts
   icon:
     position: 0
     comment: >-

--- a/layouts/_partials/assets/icon.html
+++ b/layouts/_partials/assets/icon.html
@@ -24,6 +24,15 @@
     {{ $error = $result.err }}
 {{ end }}
 
+{{- /*
+    Resolve the page context. An explicitly threaded "page" argument takes precedence over the
+    global page function, which resolves to the page that triggered the current rendering
+    context — not necessarily the page that owns the icon (e.g. when another page's render
+    materializes this page's .Content first). Callers should pass the owning page so symbol
+    registration in symbols mode lands on the correct page.
+*/ -}}
+{{- $page := or $args.page page -}}
+
 {{- $icon := string $args.icon -}}
 {{- $src := $args.src -}}
 
@@ -58,8 +67,11 @@
     {{- end -}}
 {{- end -}}
 
-{{/* Determine rendering mode from global config */}}
-{{- $mode := cond site.Params.env_bookshop_live "webfonts" site.Params.modules.fontawesome.mode -}}
+{{/*
+    Determine rendering mode from global config, with an optional per-call "mode" override. The
+    bookshop live editor always uses webfonts, as it cannot resolve static SVG resources.
+*/}}
+{{- $mode := cond site.Params.env_bookshop_live "webfonts" (or $args.mode site.Params.modules.fontawesome.mode) -}}
 {{- if not $mode -}}
     {{/* Fallback to legacy inline/embed if mode not set in config */}}
     {{- $inline := default true site.Params.modules.fontawesome.inline -}}
@@ -111,7 +123,7 @@
             {{- $output = $inject -}}
 
             {{/* Handle symbols mode - convert to symbol reference */}}
-            {{- if and (eq $mode "symbols") (page) -}}
+            {{- if and (eq $mode "symbols") $page -}}
                 {{- $symbolId := printf "%s-%s" $family $name -}}
                 {{- $definition := index (findRE "<svg[^>]*>" $output 1) 0 -}}
                 {{/* Add overflow="visible" attribute to containing SVG */}}
@@ -129,7 +141,8 @@
                 {{- $pathContent = replaceRE `</svg>\s*$` "" $pathContent -}}
                 {{/* Build clean symbol */}}
                 {{- $entry := printf `<symbol id="%s" overflow="visible" %s>%s</symbol>` $symbolId $viewBox $pathContent -}}
-                {{- page.Scratch.Add "icons" (slice $entry) -}}
+                {{- $page.Scratch.Add "icons" (slice $entry) -}}
+                {{- $page.Store.Add "hinode-icons" (slice $entry) -}}
             {{- end -}}
         {{- end -}}
     {{- else -}}
@@ -192,7 +205,7 @@
                     {{- $inject = replaceRE "width=\\\"(.*?)\\\"" "" $inject -}}
                     {{- $inject = replaceRE "height=\\\"(.*?)\\\"" "" $inject -}}
 
-                    {{- if page -}}
+                    {{- if $page -}}
                         {{/* Static icons: create symbol reference with viewBox and overflow */}}
                         {{/* Per FontAwesome docs: add overflow="visible" to prevent clipping */}}
                         {{- $symbolId := printf "%s-%s" $family $name -}}
@@ -213,7 +226,8 @@
                         {{- $pathContent = replaceRE `</svg>\s*$` "" $pathContent -}}
                         {{/* Build clean symbol */}}
                         {{- $entry := printf `<symbol id="%s" overflow="visible" %s>%s</symbol>` $symbolId $viewBox $pathContent -}}
-                        {{- page.Scratch.Add "icons" (slice $entry) -}}
+                        {{- $page.Scratch.Add "icons" (slice $entry) -}}
+                        {{- $page.Store.Add "hinode-icons" (slice $entry) -}}
                     {{- else -}}
                         {{/* Fallback to inline SVG if no page context */}}
                         {{- $output = $inject -}}
@@ -289,7 +303,7 @@
                     {{- $output = $inject -}}
 
                     {{/* Handle symbols mode - convert to symbol reference */}}
-                    {{- if and (eq $mode "symbols") (page) -}}
+                    {{- if and (eq $mode "symbols") $page -}}
                         {{- $symbolId := printf "%s-%s" $family $name -}}
                         {{- $definition := index (findRE "<svg[^>]*>" $output 1) 0 -}}
                         {{/* Add overflow="visible" attribute to containing SVG */}}
@@ -307,7 +321,8 @@
                         {{- $pathContent = replaceRE `</svg>\s*$` "" $pathContent -}}
                         {{/* Build clean symbol */}}
                         {{- $entry := printf `<symbol id="%s" overflow="visible" %s>%s</symbol>` $symbolId $viewBox $pathContent -}}
-                        {{- page.Scratch.Add "icons" (slice $entry) -}}
+                        {{- $page.Scratch.Add "icons" (slice $entry) -}}
+                        {{- $page.Store.Add "hinode-icons" (slice $entry) -}}
                     {{- end -}}
                 {{- end -}}
             {{- else -}}

--- a/layouts/_partials/assets/symbols.html
+++ b/layouts/_partials/assets/symbols.html
@@ -45,9 +45,21 @@
         {{- printf "<!-- SVG symbol map -->" | safeHTML }}
     {{ end -}}
 
+    {{/* Force content materialization before reading the icon registry, so icons used only
+         within the page's own content are registered even when the layout itself never
+         touched .Content. Cheap: .Content is computed at most once per page and cached. */}}
+    {{- $_ := .Content -}}
+
+    {{/* Read the union of the legacy Scratch key and the render-once Store key ("hinode-icons",
+         written by assets/icon.html when handed an explicit page argument); both registries
+         hold identical symbol entries during the transition and are uniq-ed below. */}}
+    {{- $icons := slice -}}
+    {{- with .Scratch.Get "icons" -}}{{- $icons = $icons | append . -}}{{- end -}}
+    {{- with .Store.Get "hinode-icons" -}}{{- $icons = $icons | append . -}}{{- end -}}
+
     {{/* Icons register in first-use order, which races across pages when the first use
          sits inside a cached partial; sort so identical icon sets emit identical bytes. */}}
     <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" display="none">
-        {{ delimit (sort (.Scratch.Get "icons" | uniq)) "\n" | safeHTML }}
+        {{ delimit (sort ($icons | uniq)) "\n" | safeHTML }}
     </svg>
 {{ end }}

--- a/layouts/_shortcodes/fa.html
+++ b/layouts/_shortcodes/fa.html
@@ -69,6 +69,7 @@
 <!-- Main code -->
 {{- if not $error -}}
     {{- partial "assets/icon.html" (dict
+        "page"         .Page
         "icon"         $fullIcon
         "inline-style" (or $args.inlineStyle $args.style)
         "wrapper"      $args.wrapper

--- a/layouts/_shortcodes/fab.html
+++ b/layouts/_shortcodes/fab.html
@@ -69,6 +69,7 @@
 <!-- Main code -->
 {{- if not $error -}}
     {{- partial "assets/icon.html" (dict
+        "page"         .Page
         "icon"         $fullIcon
         "inline-style" (or $args.inlineStyle $args.style)
         "wrapper"      $args.wrapper

--- a/layouts/_shortcodes/far.html
+++ b/layouts/_shortcodes/far.html
@@ -69,6 +69,7 @@
 <!-- Main code -->
 {{- if not $error -}}
     {{- partial "assets/icon.html" (dict
+        "page"         .Page
         "icon"         $fullIcon
         "inline-style" (or $args.inlineStyle $args.style)
         "wrapper"      $args.wrapper

--- a/layouts/_shortcodes/fas.html
+++ b/layouts/_shortcodes/fas.html
@@ -68,6 +68,7 @@
 <!-- Main code -->
 {{- if not $error -}}
     {{- partial "assets/icon.html" (dict
+        "page"         .Page
         "icon"         $fullIcon
         "inline-style" (or $args.inlineStyle $args.style)
         "wrapper"      $args.wrapper

--- a/layouts/_shortcodes/icon.html
+++ b/layouts/_shortcodes/icon.html
@@ -96,6 +96,7 @@
 <!-- Main code -->
 {{- if not $error -}}
     {{- partial "assets/icon.html" (dict
+        "page"         .Page
         "icon"         $fullIcon
         "src"          $args.src
         "inline-style" (or $args.inlineStyle $args.style)


### PR DESCRIPTION
## Render-once program — slice D2

Part of the Hinode render-once implementation program (design:
gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §4.4/§6-D2;
sidebar design §1.4 + decision §7-4).

### Changes
- **icon.html** — optional `page` argument (`or $args.page page`); replaces the bare-`page`
  symbols-mode gates and registration sites. Symbol registration dual-writes to
  `.Scratch "icons"` (legacy) AND `.Store "hinode-icons"` (render-once home) on the resolved
  page. Global-page fallback preserved when omitted.
- **Per-call `mode` override** (`symbols|svg|webfonts`) — e.g. `mode="svg"` forces one call to
  inline SVG, bypassing sprite registration (adopted by the sidebar cache slice E). Bookshop
  live still forces webfonts.
- **symbols.html** — `.Content` materialization guard + union read of Scratch ∪ Store (uniq'd,
  sorted; emission shape unchanged byte-for-byte).
- All five shortcodes (`fa/fas/far/fab/icon`) thread `"page" .Page`.
- Schema: `page` + `mode` added to `data/structures/icon.yml` (release v6.1.0).

### Gate evidence (byte-diff, hinode exampleSite @ 50b5612b, hugo v0.164.0)
- Stock ×2 + candidate ×2 (+ unpatched-main replacement control ×2): all 0 ERROR, 98/26/24
  pages, WARN sets byte-identical; diffs confined to the 3 allowlisted RSS files.
- Sprite `<symbol>` sets byte-identical vs stock on home/docs/blog pages; Store-only read
  yields the full symbol set (Store path proven end-to-end).
- Note: candidate-vs-stock also shows the 4 `webfonts/*.woff2` files — that is main's
  pre-existing Font-Awesome snapshot bump (`ebe88340`), independently confirmed with an
  unpatched-main control build; hinode picks it up via MVS on adoption.
- Independently re-verified by the program driver. Module test suite green.

Releases as **v6.1.0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)