### PR TITLE
fix: attribute diagnostic warnings to the intrinsic page (render-once D7)

### DIFF
--- a/layouts/_partials/assets/icon.html
+++ b/layouts/_partials/assets/icon.html
@@ -19,7 +19,7 @@
         "warnid"  "warn-invalid-arguments"
         "msg"     "Invalid arguments"
         "details" ($result.errmsg | append $result.warnmsg)
-        "file"    page.File
+        "file"    (or $args.page page).File
     )}}
     {{ $error = $result.err }}
 {{ end }}

--- a/layouts/_shortcodes/fa.html
+++ b/layouts/_shortcodes/fa.html
@@ -24,7 +24,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($result.errmsg | append $result.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}
@@ -60,7 +60,7 @@
     {{ partial "utilities/LogErr.html" (dict
         "partial"  "shortcodes/fa.html"
         "msg"      "Missing icon name"
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = true }}

--- a/layouts/_shortcodes/fab.html
+++ b/layouts/_shortcodes/fab.html
@@ -24,7 +24,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($result.errmsg | append $result.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}
@@ -60,7 +60,7 @@
     {{ partial "utilities/LogErr.html" (dict
         "partial"  "shortcodes/fab.html"
         "msg"      "Missing icon name"
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = true }}

--- a/layouts/_shortcodes/far.html
+++ b/layouts/_shortcodes/far.html
@@ -24,7 +24,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($result.errmsg | append $result.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}
@@ -60,7 +60,7 @@
     {{ partial "utilities/LogErr.html" (dict
         "partial"  "shortcodes/far.html"
         "msg"      "Missing icon name"
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = true }}

--- a/layouts/_shortcodes/fas.html
+++ b/layouts/_shortcodes/fas.html
@@ -24,7 +24,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($result.errmsg | append $result.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}
@@ -59,7 +59,7 @@
     {{ partial "utilities/LogErr.html" (dict
         "partial"  "shortcodes/fas.html"
         "msg"      "Missing icon name"
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = true }}

--- a/layouts/_shortcodes/icon.html
+++ b/layouts/_shortcodes/icon.html
@@ -24,7 +24,7 @@
         "warnid"   "warn-invalid-arguments"
         "msg"      "Invalid arguments"
         "details"  ($result.errmsg | append $result.warnmsg)
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
 {{ end }}
@@ -87,7 +87,7 @@
     {{ partial "utilities/LogErr.html" (dict
         "partial"  "shortcodes/icon.html"
         "msg"      "Missing icon name"
-        "file"     page.File
+        "file"     .Page.File
         "position" .Position
     )}}
     {{ $error = true }}


### PR DESCRIPTION
## Render-once program — slice D7

11 sites switched: icon partial uses D2's threaded page; all 10 shortcode sites use `.Page.File` (`.Position` already preferred by LogMsg).

Part of the Hinode render-once implementation program (design: gethinode.com `docs/superpowers/specs/2026-07-15-content-render-once-design.md` §2.3/§4.5/§6-D7, Appendix C). Diagnostics-only: replaces global-`page` warning attribution with the intrinsic page where one is in scope; no output bytes change.

**Gate:** exampleSite with all four D7 module branches replaced simultaneously — 0 ERROR, 98/26/24 pages, WARN set identical; candidate vs unpatched-main control: byte-neutral (only the 3 allowlisted RSS files). Independently re-verified by the program driver. Module test suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)