### PR TITLE
fix: trim trailing whitespace from inline SVG icon markup

### DIFF
--- a/layouts/_partials/assets/icon.html
+++ b/layouts/_partials/assets/icon.html
@@ -115,7 +115,8 @@
             {{- $content := (replaceRE $regex "" $svg.Content) -}}
             {{/* Strip XML declaration if present */}}
             {{- $content = replaceRE `<\?xml[^>]*\?>` "" $content -}}
-            {{- $content = replaceRE `^\s+` "" $content -}}
+            {{/* Trim whitespace on both ends: a trailing newline renders as a space next to adjacent text */}}
+            {{- $content = replaceRE `^\s+|\s+$` "" $content -}}
             {{- $inject := (replaceRE "xmlns=\\\"(.*?)\\\"" (printf "class=\"svg-inline--fa %s\" fill=\"currentColor\" aria-hidden=\"true\" role=\"img\"%s" $attr (or $style "")) $content) -}}
             {{/* Remove fixed width/height to allow CSS sizing (fa-2x, fa-3x, fa-4x, etc.) */}}
             {{- $inject = replaceRE "width=\\\"(.*?)\\\"" "" $inject -}}
@@ -199,7 +200,8 @@
                     {{- $content := (replaceRE $regex "" $svg.Content) -}}
                     {{/* Strip XML declaration if present */}}
                     {{- $content = replaceRE `<\?xml[^>]*\?>` "" $content -}}
-                    {{- $content = replaceRE `^\s+` "" $content -}}
+                    {{/* Trim whitespace on both ends: a trailing newline renders as a space next to adjacent text */}}
+                    {{- $content = replaceRE `^\s+|\s+$` "" $content -}}
                     {{- $inject := (replaceRE "xmlns=\\\"(.*?)\\\"" (printf "class=\"svg-inline--fa %s fa-%s %s\" fill=\"currentColor\" aria-hidden=\"true\" role=\"img\"%s" $family $name $attr (or $style "")) $content) -}}
                     {{/* Remove fixed width/height to allow CSS sizing (fa-2x, fa-3x, etc.) */}}
                     {{- $inject = replaceRE "width=\\\"(.*?)\\\"" "" $inject -}}
@@ -253,7 +255,8 @@
                     {{- $content := (replaceRE $regex "" $svg.Content) -}}
                     {{/* Strip XML declaration if present */}}
                     {{- $content = replaceRE `<\?xml[^>]*\?>` "" $content -}}
-                    {{- $content = replaceRE `^\s+` "" $content -}}
+                    {{/* Trim whitespace on both ends: a trailing newline renders as a space next to adjacent text */}}
+                    {{- $content = replaceRE `^\s+|\s+$` "" $content -}}
                     {{- $inject := (replaceRE "xmlns=\\\"(.*?)\\\"" (printf "class=\"svg-inline--fa %s fa-%s %s\" fill=\"currentColor\" aria-hidden=\"true\" role=\"img\"%s" $family $name $attr (or $style "")) $content) -}}
                     {{/* Remove fixed width/height to allow CSS sizing (fa-2x, fa-3x, etc.) */}}
                     {{- $inject = replaceRE "width=\\\"(.*?)\\\"" "" $inject -}}
@@ -289,7 +292,8 @@
                     {{- $content := (replaceRE $regex "" $svg.Content) -}}
                     {{/* Strip XML declaration if present */}}
                     {{- $content = replaceRE `<\?xml[^>]*\?>` "" $content -}}
-                    {{- $content = replaceRE `^\s+` "" $content -}}
+                    {{/* Trim whitespace on both ends: a trailing newline renders as a space next to adjacent text */}}
+                    {{- $content = replaceRE `^\s+|\s+$` "" $content -}}
                     {{/* Clean up original SVG attributes to prevent duplicates */}}
                     {{- $content = replaceRE "xmlns=\\\"(.*?)\\\"" "" $content -}}
                     {{- $content = replaceRE "class=\\\"(.*?)\\\"" "" $content -}}


### PR DESCRIPTION
## Problem

`assets/icon.html` strips only *leading* whitespace from SVG content:

```go-html-template
{{- $content = replaceRE `<\?xml[^>]*\?>` "" $content -}}
{{- $content = replaceRE `^\s+` "" $content -}}     <- no matching `\s+$`
```

A pretty-printed source SVG (XML declaration + trailing newline) therefore emits `</svg>` followed by a `"\n"` text node. Next to adjacent text that collapses to a rendered space of ~4px, on top of whatever margin utilities are in play — so an icon-plus-label pair silently gets 4px more gap than intended, purely as a function of how its source file happened to be formatted upstream.

A minified SVG (zero newline bytes) is unaffected, which is why this went unnoticed: it only shows on some icon sets.

## Fix

Add the matching trailing trim alongside each existing leading trim, as a single alternation.

**The one-sided trim occurs four times**, not once — the `src` (custom/third-party SVG) path plus three FontAwesome paths. All four are fixed so behaviour is uniform regardless of which branch an icon takes.

## Evidence

Measured downstream in a real Hinode site (`label.left − svg.right` in an icon-and-label column, headless Chromium at 1440×900):

| Source SVG | before | after |
| --- | --- | --- |
| Pretty-printed (`fi-tr/building.svg`, 4 newline bytes) | **12px** | **8px** |
| Minified (`fi-tr/list-tree.svg`, 0 newline bytes) | **8px** | **8px** |

Distinct gaps across the column went `[8, 12]` → `[8]`, and the `"\n"` text nodes between `</svg>` and the label are gone. The minified case is unchanged — that was the explicit regression risk, since a naive fix must not disturb it.

**Symbol-sprite path unaffected:** 53 distinct `<symbol>` elements extracted from a 470-page build before and after are byte-identical (`diff` empty), all well-formed with `overflow="visible"` and a `viewBox`. `$pathContent` already ran `replaceRE '</svg>\s*$'`, whose `\s*` had absorbed the trailing whitespace, so downstream derivation is untouched.

Regex semantics were also checked directly in Hugo's engine across four inputs — pretty-printed, minified, trailing `\r\n  `, and internal-newlines-only. Internal whitespace is not eaten; the minified case is byte-identical old vs new.

`pnpm test` exits 0.

## Note

Every vendored upstream FontAwesome SVG is currently minified, so the two FA paths are provably no-ops today — in practice only third-party sets trigger this. They are fixed anyway as a defence against differently-formatted assets later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
