### PR TITLE
fix: hide decorative webfont icons from assistive technology

### DIFF
--- a/layouts/_partials/assets/icon.html
+++ b/layouts/_partials/assets/icon.html
@@ -190,7 +190,7 @@
                     {{- if site.Params.modules.fontawesome.skipMissing -}}
                         {{- warnf $msg -}}
                         {{/* Fallback to webfont icon class */}}
-                        {{- $output = printf "<i class=\"%s fa-%s %s\"%s></i>" $family $name $attr (or $style "") -}}
+                        {{- $output = printf "<i class=\"%s fa-%s %s\" aria-hidden=\"true\"%s></i>" $family $name $attr (or $style "") -}}
                     {{- else -}}
                         {{- errorf $msg -}}
                     {{- end -}}
@@ -245,7 +245,7 @@
                     {{- if site.Params.modules.fontawesome.skipMissing -}}
                         {{- warnf $msg -}}
                         {{/* Fallback to webfont icon class */}}
-                        {{- $output = printf "<i class=\"%s fa-%s %s\"%s></i>" $family $name $attr (or $style "") -}}
+                        {{- $output = printf "<i class=\"%s fa-%s %s\" aria-hidden=\"true\"%s></i>" $family $name $attr (or $style "") -}}
                     {{- else -}}
                         {{- errorf $msg -}}
                     {{- end -}}
@@ -267,7 +267,7 @@
                 {{- end -}}
             {{- else -}}
                 {{/* Webfont mode - <i> tag rendered via CSS @font-face */}}
-                {{- $output = printf "<i class=\"%s fa-%s %s\"%s></i>" $family $name $attr (or $style "") -}}
+                {{- $output = printf "<i class=\"%s fa-%s %s\" aria-hidden=\"true\"%s></i>" $family $name $attr (or $style "") -}}
             {{- end -}}
         {{- else -}}
             {{/* Other icon families (Bootstrap Icons, Material Design Icons, etc.) */}}
@@ -282,7 +282,7 @@
                     {{- if site.Params.modules.fontawesome.skipMissing -}}
                         {{- warnf $msg -}}
                         {{/* Fallback to webfont icon class */}}
-                        {{- $output = printf "<i class=\"%s %s-%s %s\"%s></i>" $family $family $name $attr (or $style "") -}}
+                        {{- $output = printf "<i class=\"%s %s-%s %s\" aria-hidden=\"true\"%s></i>" $family $family $name $attr (or $style "") -}}
                     {{- else -}}
                         {{- errorf $msg -}}
                     {{- end -}}
@@ -331,7 +331,7 @@
                 {{- end -}}
             {{- else -}}
                 {{/* Webfont mode - output simple <i> tag for CSS to handle */}}
-                {{- $output = printf "<i class=\"%s %s-%s %s\"%s></i>" $family $family $name $attr (or $style "") -}}
+                {{- $output = printf "<i class=\"%s %s-%s %s\" aria-hidden=\"true\"%s></i>" $family $family $name $attr (or $style "") -}}
             {{- end -}}
         {{- end -}}
     {{- end -}}


### PR DESCRIPTION
## Problem

`layouts/_partials/assets/icon.html` injects `aria-hidden="true"` on every SVG it emits, but **none of the five `<i>` webfont emission sites carried it**. Accessibility therefore depended on the configured rendering mode — identical template calls produced hidden icons under `mode="svg"` / `mode="symbols"` and unhidden ones under `mode="webfonts"`:

```html
<!-- mode="svg" -->
<svg class="svg-inline--fa fas fa-arrow-left" fill="currentColor" aria-hidden="true" role="img" …/>

<!-- mode="webfonts" — before this PR -->
<i class="fas fa-arrow-left "></i>
```

An empty `<i>` whose glyph comes from a CSS pseudo-element can be announced by screen readers as a private-use codepoint, polluting the accessible name of any surrounding link or button.

The partial exposes no `label`, `title`, or `alt` argument (see `data/structures/icon.yml`), so **every icon it renders is decorative by contract** — which is exactly why the SVG lanes hard-code `aria-hidden="true"` unconditionally. The webfont lanes simply missed it.

## Change

Adds `aria-hidden="true"` to all five `<i>` emission sites:

| Line | Context |
|---|---|
| 193 | `symbols` mode — `skipMissing` fallback |
| 248 | `svg` mode — `skipMissing` fallback |
| 270 | `webfonts` mode — FontAwesome families |
| 285 | non-FA families — `skipMissing` fallback |
| 334 | `webfonts` mode — non-FA families |

Note the two `skipMissing` fallbacks mean this affected **all three modes**, not just `webfonts`.

Attribute placement matches the existing SVG lanes (after `class`, before `style`) and FontAwesome's [documented markup](https://docs.fontawesome.com/web/dig-deeper/accessibility) for decorative webfont icons. `role="img"` is deliberately not added — `aria-hidden` already removes the element from the accessibility tree, and an empty `role="img"` with no accessible name trips several a11y linters.

## Verification

Built the exampleSite both ways with `mode = "webfonts"`:

| | Before | After |
|---|---|---|
| Total `<i>` icons emitted | 87 | 87 |
| …carrying `aria-hidden` | **0** | **87** |

Icon count is unchanged, so nothing was dropped. Containment: exactly one output file differs, and stripping ` aria-hidden="true"` from the `<i>` tags in the "after" build makes it **byte-identical** to "before" — the attribute is the only delta.

Regression check on the default mode: a `mode = "svg"` build is **byte-identical** before and after.

`pnpm test` (= `pnpm build`) passes; it ran as the pre-commit gate.

## Related

Surfaced while reviewing gethinode/hinode#2088, which adds visually-hidden directional labels to previous/next page links. That fix's premise — that the adjacent arrow icons are already hidden from assistive technology — holds under SVG modes but did not hold under `mode="webfonts"` until this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)