### PR TITLE
fix(scss): let inline SVG icons honour the fa-width property

### DIFF
--- a/assets/scss/fontawesome.scss
+++ b/assets/scss/fontawesome.scss
@@ -40,7 +40,16 @@
 svg.svg-inline--fa {
   overflow: visible;
   height: 1em;
-  width: auto;
+  // Honour the width custom property. FontAwesome v7 no longer sets a width on
+  // the width utilities themselves: `.fa-fw` sets `--fa-width: 1.25em`, and the
+  // webfont rule reads it as `width: var(--fa-width, 1.25em)`. Reading it here
+  // too is what makes `fa-fw`, `fa-width-fixed` and `fa-width-auto` mean
+  // anything on an inline SVG — without it the class is accepted and ignored.
+  //
+  // `auto` stays the fallback, so an icon that sets no property renders exactly
+  // as before. Only the three utilities set it, and each sets it on the icon
+  // itself rather than an ancestor, so nothing inherits a width by accident.
+  width: var(--fa-width, auto);
   // Default vertical alignment for SVG icons
   vertical-align: -0.125em;
 }


### PR DESCRIPTION
## The defect

FontAwesome v7 changed how the width utilities work. `.fa-fw` no longer sets a width — it sets a **custom property**:

```css
.fa-fw,.fa-width-fixed{--fa-width:1.25em}
```

The webfont rule reads it back as `width: var(--fa-width, 1.25em)`. But the inline-SVG rule in this module hard-set `width: auto` and never read the property:

```scss
.svg-inline--fa,
svg.svg-inline--fa {
  height: 1em;
  width: auto;      // never reads --fa-width
}
```

So `fa-fw`, `fa-width-fixed` and `fa-width-auto` were **accepted and ignored** on every SVG icon. Since Hinode renders icons as inline SVG by default, that is every icon on a Hinode site.

The symptom that surfaced it: two adjacent rows in a collapsed navbar, both carrying `fa-fw`, rendering at 40px and 32px. The theme-mode toggle only looked correct because Hinode carries a one-off `.mode-toggle .label svg { width: 1.25em }` workaround for that single row — which this change makes redundant.

## The fix

```scss
width: var(--fa-width, auto);
```

`auto` stays the fallback, so an icon that sets no property renders exactly as before.

## Measured on a consuming site

```text
without fa-fw   17 icons, unchanged at 16x16 and 12x12
with fa-fw       9 icons, mixed widths -> uniform 40x32
```

Uniformity is the point of a fixed-width class, so that is the fix working rather than a side effect.

**No accidental inheritance.** Only three selectors set the property — `.fa-width-auto`, `.fa-fw, .fa-width-fixed`, and `.fa-stack-1x, .fa-stack-2x` — and each sets it on the icon itself, not on an ancestor.

## One visible change for consumers to expect

An icon carrying `fa-fw` at a large font size now occupies a 1.25em-wide box, so a square glyph centres with padding either side rather than filling it. On a 5rem card motif that shifts the glyph 10px.

Verified on two consuming sites (1117 and 2517 pages) at 1440px and 390px: nothing overflows, no page gained horizontal scroll, and clipped corner motifs still read correctly. But it is a real visual change anywhere `fa-fw` was previously inert, which is why it is called out rather than buried.

## Checks

`pnpm test` passes.